### PR TITLE
clamp arcToCubic calculations to [-1, 1] to account for rounding errors

### DIFF
--- a/src/point/arc-to-cubic/index.js
+++ b/src/point/arc-to-cubic/index.js
@@ -2,6 +2,12 @@ import { Point, C, c } from "../points"
 import isRelative from "../is-relative"
 import rotate from "../../transforms/rotate"
 
+function clamp(value, min, max) {
+  if (value < min) { return min }
+  if (value > max) { return max }
+  return value
+}
+
 export default function arcToCubic(prev, point, center = null) {
   let partial = []
   let cx, cy, f1, f2
@@ -54,8 +60,9 @@ export default function arcToCubic(prev, point, center = null) {
     cx = ((k * rx * y) / ry) + ((x1 + x2) / 2)
     cy = ((k * -ry * x) / rx) + ((y1 + y2) / 2)
 
-    f1 = Math.asin((y1 - cy) / ry)
-    f2 = Math.asin((y2 - cy) / ry)
+
+    f1 = Math.asin(clamp((y1 - cy) / ry, -1, 1))
+    f2 = Math.asin(clamp((y2 - cy) / ry, -1, 1))
 
     if (x1 < cx) {
       f1 = Math.PI - f1

--- a/src/point/arc-to-cubic/test.js
+++ b/src/point/arc-to-cubic/test.js
@@ -12,3 +12,15 @@ test("should convert the arc into a cubic curve", () => {
 
   expect(test).toEqual(expected)
 })
+test("should convert the arc into a cubic curve (even with floating point errors)", () => {
+  const prev = M(22.759, -46.5)
+  const point = A(10, 10, 0, 0, 1, 22.759, 46.5)
+  const test = arcToCubic(prev, point)
+
+  const expected = [
+    C(58.55471668975679, -46.5, 80.92703896456277, -7.7500000000000036, 23.24999999999999, 75),
+    C(61.24285267014358, 26.34401076758502, 26.331655899081635, 46.5, 22.759, 46.5),
+  ]
+
+  expect(test).toEqual(expected)
+})


### PR DESCRIPTION
Hey, great library. Wasn't sure what your contribution guidelines were.

This is a specific case where Math.asin was being passed a value outside of [-1, 1] (by an error of 0.00000002), causing f1 and f2 to be NaN